### PR TITLE
only deploy on push

### DIFF
--- a/.github/workflows/build-deploy-book.yaml
+++ b/.github/workflows/build-deploy-book.yaml
@@ -67,6 +67,7 @@ jobs:
 
       - name: Deploy to GitHub pages 🚀
         uses: JamesIves/github-pages-deploy-action@4.1.4
+        on: push
         with:
           branch: gh-pages
           folder: _book


### PR DESCRIPTION
PR deploy will fail by permission. Thus only deploy to `gh-pages` on push.